### PR TITLE
Updating Install Instructions and Adding DFCASCI Natural Orbitals Test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,47 @@
 SHCI-SCF module for PySCF
 =========================
 
-2021-02-27
+2021-06-22
 
 * Version 0.1
+
+Dependencies
+------------
+
+- [ICMPSPT PySCF Extension](https://github.com/pyscf/icmpspt)
+- [DMRGSCF PySCF Extension](https://github.com/pyscf/dmrgscf)
 
 Install
 -------
 * Install to python site-packages folder
-```
+```bash
 pip install git+https://github.com/pyscf/shciscf
 ```
 
 * Install in a custom folder for development
-```
+```bash
 git clone https://github.com/pyscf/shciscf /home/abc/local/path
+
+C_INCLUDE_PATH=$C_INCLUDE_PATH:/path_to_pyscf/pyscf/pyscf/lib/build/ python -m pip install .
 
 # Set pyscf extended module path
 echo 'export PYSCF_EXT_PATH=/home/abc/local/path:$PYSCF_EXT_PATH' >> ~/.bashrc
+
+# Setup settings file
+cp shciscf/pyscf/shciscf/settings.py.example shciscf/pyscf/shciscf/settings.py
 ```
 
+* Modify `shciscf/pyscf/shciscf/settings.py`
+
+```python
+SHCIEXE = "/your_path_to_Dice/Dice/Dice"
+SHCISCRATCHDIR = "/path_your_tmp_dir"
+SHCILIB = "/your_path_to_shciscf/shciscf/pyscf/shciscf/libSHCITools.so" 
+
+```
+
+
 You can find more details of extended modules in the document
-[extension modules](http://pyscf.org/pyscf/install.html#extension-modules)
+[extension modules](https://pyscf.org/install.html#extension-modules)
+
+

--- a/pyscf/shciscf/test/test_shci.py
+++ b/pyscf/shciscf/test/test_shci.py
@@ -15,17 +15,20 @@
 
 import unittest
 import numpy
+import scipy
 
 from pyscf import __config__
-__config__.shci_SHCIEXE = 'shci_emulator'
-__config__.shci_SHCISCRATCHDIR = '.'
+
+__config__.shci_SHCIEXE = "shci_emulator"
+__config__.shci_SHCISCRATCHDIR = "."
+from functools import reduce
 from pyscf import gto, scf, mcscf
 from pyscf.shciscf import shci
 
 # Test whether SHCI executable can be found. If it can, trigger tests that
 # require it.
 NO_SHCI = True
-if shci.settings.SHCIEXE != 'shci_emulator' and shci.settings.SHCIEXE != None:
+if shci.settings.SHCIEXE != "shci_emulator" and shci.settings.SHCIEXE != None:
     print("Found SHCI =>", shci.settings.SHCIEXE)
     NO_SHCI = False
 else:
@@ -39,8 +42,9 @@ def make_o2():
         verbose=0,
         output=None,
         atom="O 0 0 %f; O 0 0 %f" % (-b / 2, b / 2),
-        basis='ccpvdz',
-        symmetry=True)
+        basis="ccpvdz",
+        symmetry=True,
+    )
 
     # Create HF molecule
     mf = scf.RHF(mol)
@@ -52,65 +56,73 @@ def D2htoDinfh(SHCI, norb, nelec):
     from pyscf import symm
 
     coeffs = numpy.zeros(shape=(norb, norb)).astype(complex)
-    nRows = numpy.zeros(shape=(norb, ), dtype=int)
-    rowIndex = numpy.zeros(shape=(2 * norb, ), dtype=int)
-    rowCoeffs = numpy.zeros(shape=(2 * norb, ), dtype=float)
+    nRows = numpy.zeros(shape=(norb,), dtype=int)
+    rowIndex = numpy.zeros(shape=(2 * norb,), dtype=int)
+    rowCoeffs = numpy.zeros(shape=(2 * norb,), dtype=float)
 
     i, orbsym1, ncore = 0, [0] * len(SHCI.orbsym), len(SHCI.orbsym) - norb
 
     while i < norb:
-        symbol = symm.basis.linearmole_irrep_id2symb(SHCI.groupname,
-                                                     SHCI.orbsym[i + ncore])
-        if (symbol[0] == 'A'):
+        symbol = symm.basis.linearmole_irrep_id2symb(
+            SHCI.groupname, SHCI.orbsym[i + ncore]
+        )
+        if symbol[0] == "A":
             coeffs[i, i] = 1.0
             orbsym1[i] = 1
             nRows[i] = 1
             rowIndex[2 * i] = i
-            rowCoeffs[2 * i] = 1.
-            if len(symbol) == 3 and symbol[2] == 'u':
+            rowCoeffs[2 * i] = 1.0
+            if len(symbol) == 3 and symbol[2] == "u":
                 orbsym1[i] = 2
         else:
-            if (i == norb - 1):
+            if i == norb - 1:
                 print("the orbitals dont have dinfh symmetry")
                 exit(0)
             l = int(symbol[1])
             orbsym1[i], orbsym1[i + 1] = 2 * l + 3, -(2 * l + 3)
-            if (len(symbol) == 4 and symbol[2] == 'u'):
+            if len(symbol) == 4 and symbol[2] == "u":
                 orbsym1[i], orbsym1[i + 1] = orbsym1[i] + 1, orbsym1[i + 1] - 1
-            if (symbol[3] == 'x'):
-                m1, m2 = 1., -1.
+            if symbol[3] == "x":
+                m1, m2 = 1.0, -1.0
             else:
-                m1, m2 = -1., 1.
+                m1, m2 = -1.0, 1.0
 
             nRows[i] = 2
             if m1 > 0:
-                coeffs[i, i], coeffs[i, i + 1] = (
-                    (-1)**l) * 1.0 / (2.0**0.5), ((-1)**l) * 1.0j / (2.0**0.5)
+                coeffs[i, i], coeffs[i, i + 1] = ((-1) ** l) * 1.0 / (2.0 ** 0.5), (
+                    (-1) ** l
+                ) * 1.0j / (2.0 ** 0.5)
                 rowIndex[2 * i], rowIndex[2 * i + 1] = i, i + 1
             else:
-                coeffs[i, i + 1], coeffs[i, i] = (
-                    (-1)**l) * 1.0 / (2.0**0.5), ((-1)**l) * 1.0j / (2.0**0.5)
+                coeffs[i, i + 1], coeffs[i, i] = ((-1) ** l) * 1.0 / (2.0 ** 0.5), (
+                    (-1) ** l
+                ) * 1.0j / (2.0 ** 0.5)
                 rowIndex[2 * i], rowIndex[2 * i + 1] = i + 1, i
 
-            rowCoeffs[2 * i], rowCoeffs[2 * i + 1] = (
-                (-1)**l) * 1.0 / (2.0**0.5), ((-1)**l) * 1.0 / (2.0**0.5)
+            rowCoeffs[2 * i], rowCoeffs[2 * i + 1] = ((-1) ** l) * 1.0 / (2.0 ** 0.5), (
+                (-1) ** l
+            ) * 1.0 / (2.0 ** 0.5)
             i = i + 1
 
             nRows[i] = 2
-            if (m1 > 0):  #m2 is the complex number
+            if m1 > 0:  # m2 is the complex number
                 rowIndex[2 * i] = i - 1
                 rowIndex[2 * i + 1] = i
-                rowCoeffs[2 * i], rowCoeffs[
-                    2 * i + 1] = 1.0 / (2.0**0.5), -1.0 / (2.0**0.5)
-                coeffs[i, i -
-                       1], coeffs[i, i] = 1.0 / (2.0**0.5), -1.0j / (2.0**0.5)
+                rowCoeffs[2 * i], rowCoeffs[2 * i + 1] = 1.0 / (2.0 ** 0.5), -1.0 / (
+                    2.0 ** 0.5
+                )
+                coeffs[i, i - 1], coeffs[i, i] = 1.0 / (2.0 ** 0.5), -1.0j / (
+                    2.0 ** 0.5
+                )
             else:
                 rowIndex[2 * i] = i
                 rowIndex[2 * i + 1] = i - 1
-                rowCoeffs[2 * i], rowCoeffs[
-                    2 * i + 1] = 1.0 / (2.0**0.5), -1.0 / (2.0**0.5)
-                coeffs[i, i], coeffs[i, i -
-                                     1] = 1.0 / (2.0**0.5), -1.0j / (2.0**0.5)
+                rowCoeffs[2 * i], rowCoeffs[2 * i + 1] = 1.0 / (2.0 ** 0.5), -1.0 / (
+                    2.0 ** 0.5
+                )
+                coeffs[i, i], coeffs[i, i - 1] = 1.0 / (2.0 ** 0.5), -1.0j / (
+                    2.0 ** 0.5
+                )
 
         i = i + 1
 
@@ -120,46 +132,51 @@ def D2htoDinfh(SHCI, norb, nelec):
 def DinfhtoD2h(SHCI, norb, nelec):
     from pyscf import symm
 
-    nRows = numpy.zeros(shape=(norb, ), dtype=int)
-    rowIndex = numpy.zeros(shape=(2 * norb, ), dtype=int)
-    rowCoeffs = numpy.zeros(shape=(4 * norb, ), dtype=float)
+    nRows = numpy.zeros(shape=(norb,), dtype=int)
+    rowIndex = numpy.zeros(shape=(2 * norb,), dtype=int)
+    rowCoeffs = numpy.zeros(shape=(4 * norb,), dtype=float)
 
     i, ncore = 0, len(SHCI.orbsym) - norb
 
     while i < norb:
-        symbol = symm.basis.linearmole_irrep_id2symb(SHCI.groupname,
-                                                     SHCI.orbsym[i + ncore])
-        if (symbol[0] == 'A'):
+        symbol = symm.basis.linearmole_irrep_id2symb(
+            SHCI.groupname, SHCI.orbsym[i + ncore]
+        )
+        if symbol[0] == "A":
             nRows[i] = 1
             rowIndex[2 * i] = i
-            rowCoeffs[4 * i] = 1.
+            rowCoeffs[4 * i] = 1.0
         else:
             l = int(symbol[1])
 
-            if (symbol[3] == 'x'):
-                m1, m2 = 1., -1.
+            if symbol[3] == "x":
+                m1, m2 = 1.0, -1.0
             else:
-                m1, m2 = -1., 1.
+                m1, m2 = -1.0, 1.0
 
             nRows[i] = 2
             rowIndex[2 * i], rowIndex[2 * i + 1] = i, i + 1
             if m1 > 0:
-                rowCoeffs[4 * i], rowCoeffs[4 * i + 2] = (
-                    (-1)**l) * 1.0 / (2.0**0.5), 1.0 / (2.0**0.5)
+                rowCoeffs[4 * i], rowCoeffs[4 * i + 2] = ((-1) ** l) * 1.0 / (
+                    2.0 ** 0.5
+                ), 1.0 / (2.0 ** 0.5)
             else:
-                rowCoeffs[4 * i + 1], rowCoeffs[4 * i + 3] = -(
-                    (-1)**l) * 1.0 / (2.0**0.5), 1.0 / (2.0**0.5)
+                rowCoeffs[4 * i + 1], rowCoeffs[4 * i + 3] = -((-1) ** l) * 1.0 / (
+                    2.0 ** 0.5
+                ), 1.0 / (2.0 ** 0.5)
 
             i = i + 1
 
             nRows[i] = 2
             rowIndex[2 * i], rowIndex[2 * i + 1] = i - 1, i
-            if (m1 > 0):  #m2 is the complex number
-                rowCoeffs[4 * i + 1], rowCoeffs[4 * i + 3] = -(
-                    (-1)**l) * 1.0 / (2.0**0.5), 1.0 / (2.0**0.5)
+            if m1 > 0:  # m2 is the complex number
+                rowCoeffs[4 * i + 1], rowCoeffs[4 * i + 3] = -((-1) ** l) * 1.0 / (
+                    2.0 ** 0.5
+                ), 1.0 / (2.0 ** 0.5)
             else:
-                rowCoeffs[4 * i], rowCoeffs[4 * i + 2] = (
-                    (-1)**l) * 1.0 / (2.0**0.5), 1.0 / (2.0**0.5)
+                rowCoeffs[4 * i], rowCoeffs[4 * i + 2] = ((-1) ** l) * 1.0 / (
+                    2.0 ** 0.5
+                ), 1.0 / (2.0 ** 0.5)
 
         i = i + 1
 
@@ -198,7 +215,7 @@ class KnownValues(unittest.TestCase):
         # Number of orbital and electrons
         ncas = 8
         nelecas = 12
-        
+
         mc = mcscf.CASSCF(mf, ncas, nelecas)
         e_casscf = mc.kernel()[0]
 
@@ -235,20 +252,39 @@ class KnownValues(unittest.TestCase):
         dm1 = mc.fcisolver.make_rdm1(0, ncas, nelecas)
         dm_ab = mc.fcisolver.make_rdm1s()  # in MOs
         dm1_check = numpy.linalg.norm(dm1 - numpy.sum(dm_ab, axis=0))
-        self.assertLess(dm1_check,1e-5)
+        self.assertLess(dm1_check, 1e-5)
+
+    @unittest.skipIf(NO_SHCI, "No SHCI Settings Found")
+    def test_DFCASCI_natorb(self):
+        #
+        mol = gto.M(atom="C 0 0 0; C 0 0 1;", basis="ccpvdz", spin=2, verbose=0)
+        mf = scf.RHF(mol).density_fit().run()
+        ncas, nelecas = (8, 12)
+        mc = mcscf.CASCI(mf, ncas, nelecas).density_fit()
+        mc.fcisolver = shci.SHCI(mf.mol)
+        mc.natorb = True
+        mc.kernel()
+
+        mc.make_rdm1()
+        no_coeff = mc.mo_coeff
+        dm1_no = reduce(
+            numpy.dot,
+            (no_coeff.conj().T, mf.get_ovlp(), mc.make_rdm1(), mf.get_ovlp(), no_coeff),
+        )
+        numpy.testing.assert_allclose(
+            dm1_no.diagonal(), mc.mo_occ, rtol=3e-4, atol=1e-5
+        )
 
     def test_D2htoDinfh(self):
         SHCI = lambda: None
-        SHCI.groupname = 'Dooh'
-        #SHCI.orbsym = numpy.array([15,14,0,6,7,2,3,10,11,15,14,17,16,5,13,12,16,17,12,13])
-        SHCI.orbsym = numpy.array([
-            15, 14, 0, 7, 6, 2, 3, 10, 11, 15, 14, 17, 16, 5, 12, 13, 17, 16,
-            12, 13
-        ])
+        SHCI.groupname = "Dooh"
+        # SHCI.orbsym = numpy.array([15,14,0,6,7,2,3,10,11,15,14,17,16,5,13,12,16,17,12,13])
+        SHCI.orbsym = numpy.array(
+            [15, 14, 0, 7, 6, 2, 3, 10, 11, 15, 14, 17, 16, 5, 12, 13, 17, 16, 12, 13]
+        )
 
         coeffs, nRows, rowIndex, rowCoeffs, orbsym = D2htoDinfh(SHCI, 20, 20)
-        coeffs1, nRows1, rowIndex1, rowCoeffs1, orbsym1 = shci.D2htoDinfh(
-            SHCI, 20, 20)
+        coeffs1, nRows1, rowIndex1, rowCoeffs1, orbsym1 = shci.D2htoDinfh(SHCI, 20, 20)
         self.assertTrue(numpy.array_equal(coeffs1, coeffs))
         self.assertTrue(numpy.array_equal(nRows1, nRows))
         self.assertTrue(numpy.array_equal(rowIndex1, rowIndex))
@@ -257,12 +293,11 @@ class KnownValues(unittest.TestCase):
 
     def test_DinfhtoD2h(self):
         SHCI = lambda: None
-        SHCI.groupname = 'Dooh'
-        #SHCI.orbsym = numpy.array([15,14,0,6,7,2,3,10,11,15,14,17,16,5,13,12,16,17,12,13])
-        SHCI.orbsym = numpy.array([
-            15, 14, 0, 7, 6, 2, 3, 10, 11, 15, 14, 17, 16, 5, 12, 13, 17, 16,
-            12, 13
-        ])
+        SHCI.groupname = "Dooh"
+        # SHCI.orbsym = numpy.array([15,14,0,6,7,2,3,10,11,15,14,17,16,5,13,12,16,17,12,13])
+        SHCI.orbsym = numpy.array(
+            [15, 14, 0, 7, 6, 2, 3, 10, 11, 15, 14, 17, 16, 5, 12, 13, 17, 16, 12, 13]
+        )
 
         nRows, rowIndex, rowCoeffs = DinfhtoD2h(SHCI, 20, 20)
         nRows1, rowIndex1, rowCoeffs1 = shci.DinfhtoD2h(SHCI, 20, 20)


### PR DESCRIPTION
## Summary
PR has two main purposes:

1. Modify the install instructions for this module
2. Adding a test for the new features added in the[ PySCF PR 995](https://github.com/pyscf/pyscf/pull/995)

## Reasons for Changes
1. Addressing point 1 above:
    -  The install instructions in current form lead to build errors because `config.h` from PySCF isn't automatically in the `C_INCLUDE_PATH`. 
    - The install instructions also didn't include any explicit description of the dependencies on other extensions. Since `shciscf` depends on both `icmpspt` and `dmrgscf`, I've listed them as dependencies in the installation instructions. 
    - I also added a description about modifying the `settings.py` file which is required for `pyscf.shciscf` to import properly.

2. Since the new features added to PySCF in PR 995 are aimed at approximate CI solver (SHCI in this case), I've added a test for them in `shciscf/pyscf/shciscf/test/test_shci.py`

## Related Issues/PRs
- [PySCF Issue 987](https://github.com/pyscf/pyscf/issues/987)
- [PySCF Pull Request 995](https://github.com/pyscf/pyscf/pull/995)

## Tests
See `shciscf/pyscf/shciscf/test/test_shci.py`.
